### PR TITLE
Allow use of default key for ssm parameters

### DIFF
--- a/fleece/cli/config/config.py
+++ b/fleece/cli/config/config.py
@@ -337,12 +337,15 @@ def write_to_parameter_store(env, prefix, config, ssm_kms_key=None):
                 )['KeyMetadata']['KeyId']
             else:
                 ssm_kms_key_id = None
+            kwargs = {}
+            if ssm_kms_key_id:
+                kwargs["KeyId"] = ssm_kms_key_id
             ssm.put_parameter(
                 Name=ps_name,
                 Value=value,
                 Type='SecureString',
                 Overwrite=True,
-                KeyId=ssm_kms_key_id,
+                **kwargs
             )
 
     put(prefix, config)


### PR DESCRIPTION
The last change to fleece made it possible to encrypt the rendered
SSM parameters using a custom KMS key, but in the process broke the
ability to use the default key.

That's because boto3's ssm put_parameter call is sort of confusing;
the way to use the default is to avoid passing in the `KeyId` arg
entirely, but the code was setting it to None which led to a runtime
error.