### PR TITLE
Python37 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.12 3.6.1
+    - pyenv local 2.7.12 3.6.1 3.7.3
 
 test:
   pre:

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,7 +2,7 @@ boto3>=1.0.0
 connexion==1.1.9
 Flask==0.12.4
 requests==2.20.0
-ruamel.yaml==0.15.34
+ruamel.yaml==0.15.94
 six==1.11.0
 structlog==16.0.0
 Werkzeug==0.12.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,style
+envlist = py27,py36,py37,style
 
 [testenv]
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
Lambda began supporting python 37 as a runtime. This change bumps the project to include 3.7.3 as a target python env. It also includes a bump to ruamel.yaml due to a compatibility issue with 3.7 which was fixed a few versions after the pinned version. 
@ryandub 