### PR TITLE
Rename Lambda request ID key in event dict

### DIFF
--- a/fleece/log.py
+++ b/fleece/log.py
@@ -137,7 +137,7 @@ def add_request_ids_from_environment(logger, name, event_dict):
     if ENV_APIG_REQUEST_ID in os.environ:
         event_dict['api_request_id'] = os.environ[ENV_APIG_REQUEST_ID]
     if ENV_LAMBDA_REQUEST_ID in os.environ:
-        event_dict['lambda_request_id'] = os.environ[ENV_LAMBDA_REQUEST_ID]
+        event_dict['lambda.request_id'] = os.environ[ENV_LAMBDA_REQUEST_ID]
     return event_dict
 
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 boto3>=1.0.0
 connexion==1.1.9
-Flask==0.12.4
+Flask==1.0.0
 requests==2.20.0
 ruamel.yaml==0.15.34
 six==1.11.0


### PR DESCRIPTION
This helps Datadog to correlate captured log lines to the Lambda invocation, so they can be grouped together under a trace view for example.