### PR TITLE
adds support for modern xray patching

### DIFF
--- a/fleece/log.py
+++ b/fleece/log.py
@@ -203,11 +203,11 @@ def get_logger(name=None, level=None, stream=DEFAULT_STREAM,
     return log
 
 
-def initial_trace_and_context_binds(logger, trace_id, lambda_context):
+def get_initial_trace_and_context_binds(trace_id, lambda_context):
     """A helper to set up standard trace_id and lambda_context binds"""
-    return logger.new(
-        trace_id=trace_id,
-        lambda_context={
+    return {
+        "trace_id": trace_id,
+        "lambda_context": {
             "function_name": lambda_context.function_name,
             "function_version": lambda_context.function_version,
             "invoked_function_arn": lambda_context.invoked_function_arn,
@@ -216,6 +216,13 @@ def initial_trace_and_context_binds(logger, trace_id, lambda_context):
             "log_group_name": lambda_context.log_group_name,
             "log_stream_name": lambda_context.log_stream_name,
         }
+    }
+
+
+def initial_trace_and_context_binds(logger, trace_id, lambda_context):
+    """A helper to set up standard trace_id and lambda_context binds"""
+    return logger.new(
+        **get_initial_trace_and_context_binds(trace_id, lambda_context)
     )
 
 


### PR DESCRIPTION
This adds two new functions to xray which does things the new modern
way, using aws_xray_sdk.

To use it from a typical lambda module, do this:

```
from fleece import xray

...

xray.patch(["main_project_package"])

def lambda_handler(event: dict, context: t.Any) -> None:
    log = global_log.new(**xray.log_args(context))
    log.info(event)
    ...
```