### PR TITLE
Support for python 3.7/3.8 and package issues fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           name: Install Python build dependencies
           command: |
             pip install poetry==1.2.0a2
+            pip install virtualenv==20.7.2
             poetry install --only testci
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,8 @@ jobs:
       - run:
           name: Install Python build dependencies
           command: |
-            pip install poetry==1.2.0a2
-            pip install virtualenv==20.7.2
-            poetry install --only testci
+            mv ./pyproject_test.toml ./test.toml
+            poetry install
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install Python build dependencies
           command: |
-            mv ./pyproject_test.toml ./test.toml
+            mv ./pyproject_test.toml ./pyproject.toml
             poetry install
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: Install Python build dependencies
           command: |
+            pip install poetry==1.2.0a2
             poetry install --only testci
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install Python build dependencies
           command: |
-            poetry install
+            poetry install --only testci
       - run:
           name: Run tests
           command: |

--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -2,17 +2,18 @@
 from __future__ import print_function
 
 import argparse
-from datetime import datetime
 import hashlib
-from io import BytesIO
 import os
 import subprocess
 import sys
 import tarfile
 import tempfile
+from datetime import datetime
+from io import BytesIO
 
 import docker
 from docker import errors
+
 
 build_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -20,6 +21,8 @@ build_dir = os.path.abspath(os.path.dirname(__file__))
 def parse_args(args):
     parser = argparse.ArgumentParser(prog='fleece build',
                                      description='Simple Lambda builder.')
+    parser.add_argument('--python', '-py', type=str, default=None,
+                        help='Version of Python to use (27, 36, 37, 38)')
     parser.add_argument('--python36', '-3', action='store_true',
                         help='use Python 3.6 (default: Python 2.7)')
     parser.add_argument('--inject-build-info', action='store_true',
@@ -51,6 +54,9 @@ def parse_args(args):
     parser.add_argument('service_dir', type=str,
                         help=('directory where the service is located '
                               '(default: $pwd)'))
+    result = parser.parse_args(args)
+    if _get_python_version(result) is None:
+        sys.exit(1)
     return parser.parse_args(args)
 
 
@@ -137,8 +143,25 @@ def create_volume_container(image='alpine:3.4', command='/bin/true', **kwargs):
     return container
 
 
+def _get_python_version(args):
+    if args.python is None:
+        if args.python36:
+            return 'python36'
+        return 'python27'
+    else:
+        if args.python36:
+            print("Error: --python36 and --python cannot be used together.")
+            return None
+        # Accomodate people who want to put a single dot in there.
+        version = args.python.replace('.', '', 1)
+        if version not in ["27", "36", "37", "38"]:
+            print('Unrecognized Python version "{}"'.format(args.python))
+            return None
+        return 'python' + version
+
+
 def build(args):
-    python_version = 'python36' if args.python36 else 'python27'
+    python_version = _get_python_version(args)
     inject_build_info = args.inject_build_info
     service_dir = os.path.abspath(args.service_dir)
     service_name = os.path.basename(service_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ bandit        = "^1.6.2"
 "ruamel.yaml" = "^0.15.34"
 Flask         = "^1.1.1"
 connexion     = "^1.1.9"
+virtualenv    = "20.7.2"
 
 [tool.taskipy.tasks]
 pytest = "pytest --junitxml=test-results/junit.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,44 @@ wsgi = [
 [tool.poetry.dependencies]
 python    = "^3.6"
 # connecxion
+connexion     = { version = ">=1.1.9", optional = true }
+Flask         = { version = ">=1.1.1", optional = true }
+# cli
+docker        = { version = ">=3.5.1", optional = true }
+PyYAML        = { version = ">=3.12", optional = true }
+"ruamel.yaml" = { version = ">=0.15.34", optional = true }
+# wsgi and connecxion
+Werkzeug      = { version = ">=0.15.5", optional = true }
+structlog     = ">=15.3.0"
+requests      = ">=2.9.1"
+boto3         = ">=1.0.0"
+wrapt         = ">=1.10.10"
+
+[tool.poetry.dev-dependencies]
+coverage      = ">=4.0.3"
+flake8        = ">=2.5.1"
+mock          = ">=1.3.0"
+nose          = ">=1.3.7"
+pylint        = ">=1.5.4"
+docker        = ">=3.5.1"
+taskipy       = ">=1.2.1"
+moto          = ">=1.3.14"
+black         = ">=19.10b0"
+safety        = ">=1.9.0"
+isort         = ">=4.3.21"
+pytest        = ">=5.4.1"
+Werkzeug      = ">=0.15.5"
+bandit        = ">=1.6.2"
+"ruamel.yaml" = ">=0.15.34"
+Flask         = ">=1.1.1"
+connexion     = ">=1.1.9"
+
+[tool.poetry.group.testci]
+optional = true
+
+[tool.poetry.group.testci.dependencies]
+python    = "^3.6"
+# connecxion
 connexion     = { version = "^1.1.9", optional = true }
 Flask         = { version = "^1.1.1", optional = true }
 # cli
@@ -63,8 +101,6 @@ requests      = "^2.9.1"
 boto3         = "^1.0.0"
 wrapt         = "^1.10.10"
 click         = "8.0.1"
-
-[tool.poetry.dev-dependencies]
 coverage      = "^4.0.3"
 flake8        = "^3.8.3"
 mock          = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ bandit        = "^1.6.2"
 "ruamel.yaml" = "^0.15.34"
 Flask         = "^1.1.1"
 connexion     = "^1.1.9"
-virtualenv    = "20.7.2"
 
 [tool.taskipy.tasks]
 pytest = "pytest --junitxml=test-results/junit.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ structlog     = "^20.1.0"
 requests      = "^2.9.1"
 boto3         = "^1.0.0"
 wrapt         = "^1.10.10"
+click         = "8.0.1"
 
 [tool.poetry.dev-dependencies]
 coverage      = "^4.0.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,15 +87,10 @@ optional = true
 
 [tool.poetry.group.testci.dependencies]
 python    = "^3.6"
-# connecxion
-connexion     = { version = "^1.1.9", optional = true }
-Flask         = { version = "^1.1.1", optional = true }
+
 # cli
-docker        = { version = "^3.5.1", optional = true }
 PyYAML        = { version = "5.4", optional = true }
-"ruamel.yaml" = { version = "^0.15.34", optional = true }
 # wsgi and connecxion
-Werkzeug      = { version = "^0.15.5", optional = true }
 structlog     = "^20.1.0"
 requests      = "^2.9.1"
 boto3         = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fleece"
-version = "1.0.0"
+version = "1.1.0"
 description = "Wrap the lamb...da"
 license = "Apache-2.0"
 readme = "README.md"
@@ -50,37 +50,37 @@ wsgi = [
 [tool.poetry.dependencies]
 python    = "^3.6"
 # connecxion
-connexion     = { version = ">=1.1.9", optional = true }
-Flask         = { version = ">=1.1.1", optional = true }
+connexion     = { version = "^1.1.9", optional = true }
+Flask         = { version = "^1.1.1", optional = true }
 # cli
-docker        = { version = ">=3.5.1", optional = true }
-PyYAML        = { version = ">=3.12", optional = true }
-"ruamel.yaml" = { version = ">=0.15.34", optional = true }
+docker        = { version = "^3.5.1", optional = true }
+PyYAML        = { version = "5.4", optional = true }
+"ruamel.yaml" = { version = "^0.15.34", optional = true }
 # wsgi and connecxion
-Werkzeug      = { version = ">=0.15.5", optional = true }
-structlog     = ">=15.3.0"
-requests      = ">=2.9.1"
-boto3         = ">=1.0.0"
-wrapt         = ">=1.10.10"
+Werkzeug      = { version = "^0.15.5", optional = true }
+structlog     = "^20.1.0"
+requests      = "^2.9.1"
+boto3         = "^1.0.0"
+wrapt         = "^1.10.10"
 
 [tool.poetry.dev-dependencies]
-coverage      = ">=4.0.3"
-flake8        = ">=2.5.1"
-mock          = ">=1.3.0"
-nose          = ">=1.3.7"
-pylint        = ">=1.5.4"
-docker        = ">=3.5.1"
-taskipy       = ">=1.2.1"
-moto          = ">=1.3.14"
-black         = ">=19.10b0"
-safety        = ">=1.9.0"
-isort         = ">=4.3.21"
-pytest        = ">=5.4.1"
-Werkzeug      = ">=0.15.5"
-bandit        = ">=1.6.2"
-"ruamel.yaml" = ">=0.15.34"
-Flask         = ">=1.1.1"
-connexion     = ">=1.1.9"
+coverage      = "^4.0.3"
+flake8        = "^3.8.3"
+mock          = "1.0.1"
+nose          = "^1.3.7"
+pylint        = "^1.5.4"
+docker        = "^3.5.1"
+taskipy       = "^1.2.1"
+moto          = "^1.3.14"
+black         = "^19.10b0"
+safety        = "^1.9.0"
+isort         = "^4.3.21"
+pytest        = "^5.4.1"
+Werkzeug      = "^0.15.5"
+bandit        = "^1.6.2"
+"ruamel.yaml" = "^0.15.34"
+Flask         = "^1.1.1"
+connexion     = "^1.1.9"
 
 [tool.taskipy.tasks]
 pytest = "pytest --junitxml=test-results/junit.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,6 @@ ci = "task pytest && task black_ci && task flake8 && task safety && task bandit 
 force_single_line = true
 
 [build-system]
-requires = ["poetry>=1.2.0a2"]
+requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,6 @@ ci = "task pytest && task black_ci && task flake8 && task safety && task bandit 
 force_single_line = true
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.2.0a2"]
 build-backend = "poetry.masonry.api"
 

--- a/pyproject_test.toml
+++ b/pyproject_test.toml
@@ -50,37 +50,38 @@ wsgi = [
 [tool.poetry.dependencies]
 python    = "^3.6"
 # connecxion
-connexion     = { version = ">=1.1.9", optional = true }
-Flask         = { version = ">=1.1.1", optional = true }
+connexion     = { version = "^1.1.9", optional = true }
+Flask         = { version = "^1.1.1", optional = true }
 # cli
-docker        = { version = ">=3.5.1", optional = true }
-PyYAML        = { version = ">=3.12", optional = true }
-"ruamel.yaml" = { version = ">=0.15.34", optional = true }
+docker        = { version = "^3.5.1", optional = true }
+PyYAML        = { version = "5.4", optional = true }
+"ruamel.yaml" = { version = "^0.15.34", optional = true }
 # wsgi and connecxion
-Werkzeug      = { version = ">=0.15.5", optional = true }
-structlog     = ">=15.3.0"
-requests      = ">=2.9.1"
-boto3         = ">=1.0.0"
-wrapt         = ">=1.10.10"
+Werkzeug      = { version = "^0.15.5", optional = true }
+structlog     = "^20.1.0"
+requests      = "^2.9.1"
+boto3         = "^1.0.0"
+wrapt         = "^1.10.10"
+click         = "8.0.1"
 
 [tool.poetry.dev-dependencies]
-coverage      = ">=4.0.3"
-flake8        = ">=2.5.1"
-mock          = ">=1.3.0"
-nose          = ">=1.3.7"
-pylint        = ">=1.5.4"
-docker        = ">=3.5.1"
-taskipy       = ">=1.2.1"
-moto          = ">=1.3.14"
-black         = ">=19.10b0"
-safety        = ">=1.9.0"
-isort         = ">=4.3.21"
-pytest        = ">=5.4.1"
-Werkzeug      = ">=0.15.5"
-bandit        = ">=1.6.2"
-"ruamel.yaml" = ">=0.15.34"
-Flask         = ">=1.1.1"
-connexion     = ">=1.1.9"
+coverage      = "^4.0.3"
+flake8        = "^3.8.3"
+mock          = "1.0.1"
+nose          = "^1.3.7"
+pylint        = "^1.5.4"
+docker        = "^3.5.1"
+taskipy       = "^1.2.1"
+moto          = "^1.3.14"
+black         = "^19.10b0"
+safety        = "^1.9.0"
+isort         = "^4.3.21"
+pytest        = "^5.4.1"
+Werkzeug      = "^0.15.5"
+bandit        = "^1.6.2"
+"ruamel.yaml" = "^0.15.34"
+Flask         = "^1.1.1"
+connexion     = "^1.1.9"
 
 [tool.taskipy.tasks]
 pytest = "pytest --junitxml=test-results/junit.xml"


### PR DESCRIPTION
Added support to build lambda functions with python3.7 and python3.8

Pinned/ jumped versions for few packages 

- structlog
- mock
- flake8
- PyYAML
- click