### PR TITLE
Support for python37/38

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: Install Python build dependencies
           command: |
+            mv ./pyproject_test.toml ./pyproject.toml
             poetry install
       - run:
           name: Run tests

--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -2,17 +2,18 @@
 from __future__ import print_function
 
 import argparse
-from datetime import datetime
 import hashlib
-from io import BytesIO
 import os
 import subprocess
 import sys
 import tarfile
 import tempfile
+from datetime import datetime
+from io import BytesIO
 
 import docker
 from docker import errors
+
 
 build_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -20,6 +21,8 @@ build_dir = os.path.abspath(os.path.dirname(__file__))
 def parse_args(args):
     parser = argparse.ArgumentParser(prog='fleece build',
                                      description='Simple Lambda builder.')
+    parser.add_argument('--python', '-py', type=str, default=None,
+                        help='Version of Python to use (27, 36, 37, 38)')
     parser.add_argument('--python36', '-3', action='store_true',
                         help='use Python 3.6 (default: Python 2.7)')
     parser.add_argument('--inject-build-info', action='store_true',
@@ -51,6 +54,9 @@ def parse_args(args):
     parser.add_argument('service_dir', type=str,
                         help=('directory where the service is located '
                               '(default: $pwd)'))
+    result = parser.parse_args(args)
+    if _get_python_version(result) is None:
+        sys.exit(1)
     return parser.parse_args(args)
 
 
@@ -137,8 +143,25 @@ def create_volume_container(image='alpine:3.4', command='/bin/true', **kwargs):
     return container
 
 
+def _get_python_version(args):
+    if args.python is None:
+        if args.python36:
+            return 'python36'
+        return 'python27'
+    else:
+        if args.python36:
+            print("Error: --python36 and --python cannot be used together.")
+            return None
+        # Accomodate people who want to put a single dot in there.
+        version = args.python.replace('.', '', 1)
+        if version not in ["27", "36", "37", "38"]:
+            print('Unrecognized Python version "{}"'.format(args.python))
+            return None
+        return 'python' + version
+
+
 def build(args):
-    python_version = 'python36' if args.python36 else 'python27'
+    python_version = _get_python_version(args)
     inject_build_info = args.inject_build_info
     service_dir = os.path.abspath(args.service_dir)
     service_name = os.path.basename(service_dir)

--- a/fleece/handlers/wsgi.py
+++ b/fleece/handlers/wsgi.py
@@ -3,7 +3,7 @@ from werkzeug.test import EnvironBuilder
 
 def build_wsgi_environ_from_event(event):
     """Create a WSGI environment from the proxy integration event."""
-    params = event.get("queryStringParameters")
+    params = event.get("multiValueQueryStringParameters")
     environ = EnvironBuilder(
         method=event.get("httpMethod") or "GET",
         path=event.get("path") or "/",

--- a/pyproject_test.toml
+++ b/pyproject_test.toml
@@ -50,37 +50,38 @@ wsgi = [
 [tool.poetry.dependencies]
 python    = "^3.6"
 # connecxion
-connexion     = { version = ">=1.1.9", optional = true }
-Flask         = { version = ">=1.1.1", optional = true }
+connexion     = { version = "^1.1.9", optional = true }
+Flask         = { version = "^1.1.1", optional = true }
 # cli
-docker        = { version = ">=3.5.1", optional = true }
-PyYAML        = { version = ">=3.12", optional = true }
-"ruamel.yaml" = { version = ">=0.15.34", optional = true }
+docker        = { version = "^3.5.1", optional = true }
+PyYAML        = { version = "5.4", optional = true }
+"ruamel.yaml" = { version = "^0.15.34", optional = true }
 # wsgi and connecxion
-Werkzeug      = { version = ">=0.15.5", optional = true }
-structlog     = ">=15.3.0"
-requests      = ">=2.9.1"
-boto3         = ">=1.0.0"
-wrapt         = ">=1.10.10"
+Werkzeug      = { version = "^0.15.5", optional = true }
+structlog     = "^20.1.0"
+requests      = "^2.9.1"
+boto3         = "^1.0.0"
+wrapt         = "^1.10.10"
+click         = "8.0.1"
 
 [tool.poetry.dev-dependencies]
-coverage      = ">=4.0.3"
-flake8        = ">=2.5.1"
-mock          = ">=1.3.0"
-nose          = ">=1.3.7"
-pylint        = ">=1.5.4"
-docker        = ">=3.5.1"
-taskipy       = ">=1.2.1"
-moto          = ">=1.3.14"
-black         = ">=19.10b0"
-safety        = ">=1.9.0"
-isort         = ">=4.3.21"
-pytest        = ">=5.4.1"
-Werkzeug      = ">=0.15.5"
-bandit        = ">=1.6.2"
-"ruamel.yaml" = ">=0.15.34"
-Flask         = ">=1.1.1"
-connexion     = ">=1.1.9"
+coverage      = "^4.0.3"
+flake8        = "^3.8.3"
+mock          = "1.0.1"
+nose          = "^1.3.7"
+pylint        = "^1.5.4"
+docker        = "^3.5.1"
+taskipy       = "^1.2.1"
+moto          = "^1.3.14"
+black         = "^19.10b0"
+safety        = "^1.9.0"
+isort         = "^4.3.21"
+pytest        = "^5.4.1"
+Werkzeug      = "^0.15.5"
+bandit        = "^1.6.2"
+"ruamel.yaml" = "^0.15.34"
+Flask         = "^1.1.1"
+connexion     = "^1.1.9"
 
 [tool.taskipy.tasks]
 pytest = "pytest --junitxml=test-results/junit.xml"
@@ -103,4 +104,3 @@ force_single_line = true
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
-


### PR DESCRIPTION
- Version bump from 1.0.0. to 1.1.0
-  Support for python versions 3.7 + 3.8 (in addition to 3.6 + 2.7)
- Alternate TOML file for CircleCI tests only (with restricted dependency)