### PR TITLE
[build] Upgrade pip before installing dependencies

### DIFF
--- a/fleece/cli/build/docker_build_lambda.sh
+++ b/fleece/cli/build/docker_build_lambda.sh
@@ -5,6 +5,7 @@ if [[ ! -f /build_cache/${DEPENDENCIES_SHA}.zip ]] || [[ "$REBUILD_DEPENDENCIES"
     echo "rebuilding dependencies"
     rm -rf /build_cache/*
     mkdir /tmp/build
+    /usr/bin/pip-${python_version:6:1}.${python_version:7:1} install -U pip
     /usr/bin/pip-${python_version:6:1}.${python_version:7:1} install -r /requirements/requirements.txt -t /tmp/build
     cd /tmp/build
     zip -X -r /build_cache/${DEPENDENCIES_SHA}.zip .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fleece"
-version = "1.1.0"
+version = "1.1.1"
 description = "Wrap the lamb...da"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Certain dependencies, such as more recent versions of Cryptography can only be installed with more recent versions of pip. Let's make sure we're always using the latest version.